### PR TITLE
Update JDBC-Driver to 42.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 6.0.1
+* Updated JDBC driver
+
 ## 6.0.0
-* Inital open-source release
+* Initial open-source release

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.0-801.jdbc4</version>
+			<version>42.5.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
It seems like that the newest JDBC-Driver has no conflict with our code. For more information read the comments in the issue (https://github.com/xdev-software/xapi-db-postgresql/issues/3)